### PR TITLE
fix tests on MacOS

### DIFF
--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -325,7 +325,13 @@ fn setup_writes_migration_dir_as_relative_path() {
 fn setup_writes_migration_dir_as_arg_as_relative_path() {
     let p = project("setup_writes_migration_dir_as_arg_as_relative_path").build();
 
-    let migrations_dir_arg = p.directory_path().join("foo").display().to_string();
+    let migrations_dir_arg = p
+        .directory_path()
+        .canonicalize()
+        .unwrap()
+        .join("foo")
+        .display()
+        .to_string();
     let result = p
         .command("setup")
         .arg(format!("--migration-dir={}", migrations_dir_arg))


### PR DESCRIPTION
On MacOS, the project directory (created by tempdir), is in `/var/folders/`...

This `/var` directory is a symlink to `/private/var`

In the function `create_config_file()`, the `current_path` parameter used in the function `convert_absolute_path_to_relative()` is defined by calling `find_project_root()` which return a path in `/private/var/`...

In the test "setup_writes_migration_dir_as_relative_path", when the function `convert_absolute_path_to_relative()` is called, `target_path` and `current_path` are both in `/private/var` and everything is fine.

the test "setup_writes_migration_dir_as_arg_as_relative_path" uses `p.directory()`, which return a path in `/var`
So, when the function `convert_absolute_path_to_relative()` is called, `target_path` is in `/var/`, but `current_path` is in `/private/var`

The resulting diesel.toml file contains :

```
dir = "../../../../../../../var/folders/by/lfy0tf8939qflt_lsmzt0mzr0000gn/T/setup_writes_migration_dir_as_arg_as_relative_pathMYasaL/foo"
```

and that value is not what we expect ;)

So, I added a call to `canonicalize()` after `p.directory_path()` so that the path is resolved to `/private/var/`...
=> the tests pass

PS: I hope my english is comprehensible enough ;)